### PR TITLE
Add organisation URI to publiccode.yml

### DIFF
--- a/publiccode.yml
+++ b/publiccode.yml
@@ -8,6 +8,7 @@ platforms:
 developmentStatus: beta
 softwareType: standalone/web
 organisation:
+  uri: https://ld.admin.ch/canton/12
   name: DCC Data Competence Center - Statistisches Amt Kanton Basel-Stadt
 description:
   en:


### PR DESCRIPTION
Add official URI for Kanton Basel-Stadt (https://ld.admin.ch/canton/12) - required for inclusion in the federal open source catalogue.