### PR TITLE
feat: add error handling for translation failures

### DIFF
--- a/app/composables/useTranslate.ts
+++ b/app/composables/useTranslate.ts
@@ -1,4 +1,4 @@
-import { isApiError } from "@dcc-bs/communication.bs.js";
+import { ApiError, isApiError } from "@dcc-bs/communication.bs.js";
 import { watchDebounced } from "@vueuse/core";
 import type { Domain } from "~/models/domain";
 import type { LanguageCode } from "~/models/languages";
@@ -16,6 +16,8 @@ import {
 export function useTranslate() {
     const translationService = useService(TranslationService);
     const { t } = useI18n();
+    const { showError } = useUserFeedback();
+    const logger = useLogger();
 
     const tone = useCookie<Tone>("tone", { default: () => "default" });
     const domain = useCookie<Domain>("domain", { default: () => "None" });
@@ -136,6 +138,26 @@ export function useTranslate() {
                 }
             } catch (_error) {
                 if (!signal.aborted) {
+                    showError(new Error(t("api_error.unexpected_error")));
+                }
+            }
+        } catch (error: unknown) {
+            if (!error) {
+                showError(new Error(t("api_error.unexpected_error")));
+                return;
+            }
+
+            logger.info(error, "Error while translationg");
+
+            if (
+                isApiError(error) ||
+                (typeof error === "object" &&
+                    "message" in error &&
+                    "name" in error)
+            ) {
+                if (isApiError(error)) {
+                    showError(error);
+                } else {
                     showError(new Error(t("api_error.unexpected_error")));
                 }
             }

--- a/app/composables/useTranslate.ts
+++ b/app/composables/useTranslate.ts
@@ -160,6 +160,8 @@ export function useTranslate() {
                 } else {
                     showError(new Error(t("api_error.unexpected_error")));
                 }
+            } else {
+                showError(new Error(t("api_error.unexpected_error")));
             }
         } finally {
             isTranslating.value = false;

--- a/i18n/locales/de.json
+++ b/i18n/locales/de.json
@@ -278,7 +278,8 @@
         "translation": {
             "errorTimeout": "Übersetzung dauerte zu lange. Versuchen Sie einen kürzeren Text.",
             "aborted": "Übersetzung abgebrochen.",
-            "unexpected_error": "Ein unerwarteter Fehler ist aufgetreten. Möglicherweise ist der Server nicht verfügbar. Falls der Fehler weiterhin auftritt, verwenden Sie bitte die Feedback-Schaltfläche, um uns eine Nachricht zu senden."
+            "unexpected_error": "Ein unerwarteter Fehler ist aufgetreten. Möglicherweise ist der Server nicht verfügbar. Falls der Fehler weiterhin auftritt, verwenden Sie bitte die Feedback-Schaltfläche, um uns eine Nachricht zu senden.",
+            "invalid_json_response": "Ein unerwarteter Fehler ist aufgetreten. Möglicherweise ist der Server nicht erreichbar. Falls der Fehler weiterhin auftritt, nutzen Sie bitte die Feedback-Funktion, um uns eine Nachricht zu senden."
         },
         "conversion": {
             "no_document": "Kein Dokument gefunden. Versuchen Sie, das Dokument erneut hochladen.",

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -278,7 +278,8 @@
         "translation": {
             "errorTimeout": "Translation request timed out. Try a shorter text.",
             "aborted": "Translation aborted.",
-            "unexpected_error": "Unexpected error occurred. Maybe the server is down, if the error persists. Please use the feedback button to send us a message."
+            "unexpected_error": "Unexpected error occurred. Maybe the server is down, if the error persists. Please use the feedback button to send us a message.",
+            "invalid_json_response": "An unexpected error occurred. The server may be unavailable. If the error persists, please use the feedback function to send us a message."
         },
         "conversion": {
             "no_document": "No document found. Try to upload the document again.",


### PR DESCRIPTION
Catch and display user-friendly errors when translation requests fail, including handling for API errors and unexpected error shapes.